### PR TITLE
added support & tests for mini_magick

### DIFF
--- a/carrierwave-meta.gemspec
+++ b/carrierwave-meta.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<rspec-rails>, ">= 2.6")
   s.add_development_dependency(%q<sqlite3-ruby>)    
   s.add_development_dependency(%q<rmagick>)
+  s.add_development_dependency(%q<mini_magick>)
   s.add_development_dependency(%q<mime-types>)
 end

--- a/lib/carrierwave-meta/meta.rb
+++ b/lib/carrierwave-meta/meta.rb
@@ -51,9 +51,12 @@ module CarrierWave
         [].tap do |size|
           if self.file.content_type =~ /image/
             manipulate! do |img|
-              if img.is_a?(::Magick::Image)
+              if defined?(::Magick::Image) && img.is_a?(::Magick::Image)
                 size << img.columns
                 size << img.rows
+              elsif defined?(::MiniMagick::Image) && img.is_a?(::MiniMagick::Image)
+                size << img["width"]
+                size << img["height"]
               else
                 raise "Only RMagick is supported yet. Fork and update it."
               end        

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ rescue Bundler::GemNotFound
     "Did you run `bundle install`?"
 end
 
+PROCESSOR = (ENV["PROCESSOR"] || :rmagick).to_sym
+
 require 'mime/types'
 require 'carrierwave'
 require 'carrierwave-meta'

--- a/spec/support/test_uploader.rb
+++ b/spec/support/test_uploader.rb
@@ -1,5 +1,9 @@
 class TestUploader < CarrierWave::Uploader::Base
-  include CarrierWave::RMagick
+  if PROCESSOR == :mini_magick
+    include CarrierWave::MiniMagick
+  else
+    include CarrierWave::RMagick
+  end
   include CarrierWave::Meta
   
   def store_dir


### PR DESCRIPTION
Hi,
I added support for mini_magick, and made a little adjustment to the tests. You can now set the environment variable 'PROCESSOR' to set with which processor to check. All tests were passing on my machine.
Hope you find this useful.

Best regards,
Fabian
