### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/carrierwave-meta/meta.rb
+++ b/lib/carrierwave-meta/meta.rb
@@ -20,51 +20,49 @@ module CarrierWave
       model_delegate_attribute :height, 0
     end
 
-    module InstanceMethods
-      def store_meta
-        if self.file.present?
-          dimensions = get_dimensions
-          width, height = dimensions
-          self.content_type = self.file.content_type
-          self.file_size = self.file.size
-          self.image_size = dimensions
-          self.width = width
-          self.height = height
-        end
+    def store_meta
+      if self.file.present?
+        dimensions = get_dimensions
+        width, height = dimensions
+        self.content_type = self.file.content_type
+        self.file_size = self.file.size
+        self.image_size = dimensions
+        self.width = width
+        self.height = height
       end
-      
-      def set_content_type(file = nil)
-        set_content_type(true)
-      end
-      
-      def image_size_s
-        image_size.join('x')
-      end
-      
-      private
-      def call_store_meta(file = nil)
-        # Re-retrieve metadata for a file only if model is not present OR model is not saved.
-        store_meta if self.model.nil? || (self.model.respond_to?(:new_record?) && self.model.new_record?)
-      end
-      
-      def get_dimensions
-        [].tap do |size|
-          if self.file.content_type =~ /image/
-            manipulate! do |img|
-              if defined?(::Magick::Image) && img.is_a?(::Magick::Image)
-                size << img.columns
-                size << img.rows
-              elsif defined?(::MiniMagick::Image) && img.is_a?(::MiniMagick::Image)
-                size << img["width"]
-                size << img["height"]
-              else
-                raise "Only RMagick is supported yet. Fork and update it."
-              end        
-              img
-            end
+    end
+    
+    def set_content_type(file = nil)
+      set_content_type(true)
+    end
+    
+    def image_size_s
+      image_size.join('x')
+    end
+    
+    private
+    def call_store_meta(file = nil)
+      # Re-retrieve metadata for a file only if model is not present OR model is not saved.
+      store_meta if self.model.nil? || (self.model.respond_to?(:new_record?) && self.model.new_record?)
+    end
+    
+    def get_dimensions
+      [].tap do |size|
+        if self.file.content_type =~ /image/
+          manipulate! do |img|
+            if defined?(::Magick::Image) && img.is_a?(::Magick::Image)
+              size << img.columns
+              size << img.rows
+            elsif defined?(::MiniMagick::Image) && img.is_a?(::MiniMagick::Image)
+              size << img["width"]
+              size << img["height"]
+            else
+              raise "Only RMagick is supported yet. Fork and update it."
+            end        
+            img
           end
         end
-      end        
-    end
+      end
+    end        
   end
 end

--- a/lib/carrierwave-meta/model_delegate_attribute.rb
+++ b/lib/carrierwave-meta/model_delegate_attribute.rb
@@ -33,15 +33,13 @@ module CarrierWave
       end
     end
     
-    module InstanceMethods
-      private
-      def model_getter_name(attribute)
-        name = []
-        name << mounted_as if mounted_as.present?
-        name << version_name if version_name.present?
-        name << attribute
-        name.join('_')
-      end
+    private
+    def model_getter_name(attribute)
+      name = []
+      name << mounted_as if mounted_as.present?
+      name << version_name if version_name.present?
+      name << attribute
+      name.join('_')
     end
   end
 end


### PR DESCRIPTION
When using the gem, Rails displays the following warning:

```
DEPRECATION WARNING: The InstanceMethods module inside ActiveSupport::Concern will be no longer included automatically. Please define instance methods directly in CarrierWave::Meta instead.
```

This is fixed by moving the instance methods out of the InstanceMethods module.
