### PR TITLE
Support for retrieving metadata from PDF and PostScript image files

### DIFF
--- a/lib/carrierwave-meta/meta.rb
+++ b/lib/carrierwave-meta/meta.rb
@@ -48,7 +48,7 @@ module CarrierWave
 
     def get_dimensions
       [].tap do |size|
-        if self.file.content_type =~ /image/
+        if self.file.content_type =~ /image|postscript|pdf/
           manipulate! do |img|
             if defined?(::Magick::Image) && img.is_a?(::Magick::Image)
               size << img.columns


### PR DESCRIPTION
Added support for retrieving metadata from PDF and PostScript image files as there is support in ImageMagick for their processing.
