### PR TITLE
Remove duplicate mime-types dependency

### DIFF
--- a/carrierwave-meta.gemspec
+++ b/carrierwave-meta.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency(%q<sqlite3-ruby>)
   s.add_development_dependency(%q<rmagick>)
   s.add_development_dependency(%q<mini_magick>)
-  s.add_development_dependency(%q<mime-types>)
   s.add_development_dependency(%q<carrierwave-imagesorcery>)
   s.add_development_dependency(%q<carrierwave-vips>)
   s.add_development_dependency(%q<fog>, '~> 1.3.1')


### PR DESCRIPTION
Bundler 1.10 validates gemspecs of all used gems and reports `duplicate
dependency on mime-types`. This removes the development dependency for
this gem, as it is not needed when a runtime dependency is already
added.
