### PR TITLE
Processing pdf files

### DIFF
--- a/lib/carrierwave-meta/meta.rb
+++ b/lib/carrierwave-meta/meta.rb
@@ -64,24 +64,25 @@ module CarrierWave
           CarrierWave::Meta.ghostscript_enabled
 
         is_dimensionable = is_image || is_pdf
-
-        manipulate! do |img|
-          if processor?(:rmagick, img) && is_dimensionable
-            size << img.columns
-            size << img.rows
-          elsif processor?(:mini_magick, img) && is_dimensionable
-            size << img['width']
-            size << img['height']
-          elsif processor?(:socrecy, img) && is_image
-            size << img.dimensions[:x].to_i
-            size << img.dimensions[:y].to_i
-          elsif processor?(:vips, img) && is_image
-            size << img.x_size
-            size << img.y_size
-          else
-            raise "Unsupported file type/image processor (use RMagick, MiniMagick, ImageSorcery, VIPS)"
+	if is_dimensionable
+          manipulate! do |img|
+            if processor?(:rmagick, img) && is_dimensionable
+              size << img.columns
+              size << img.rows
+            elsif processor?(:mini_magick, img) && is_dimensionable
+              size << img['width']
+              size << img['height']
+            elsif processor?(:socrecy, img) && is_image
+              size << img.dimensions[:x].to_i
+              size << img.dimensions[:y].to_i
+            elsif processor?(:vips, img) && is_image
+              size << img.x_size
+              size << img.y_size
+            else
+              raise "Unsupported file type/image processor (use RMagick, MiniMagick, ImageSorcery, VIPS)"
+            end
+            img
           end
-          img
         end
       end
     rescue CarrierWave::ProcessingError


### PR DESCRIPTION
Do not fail with `Unsupported file type/image processor` error when trying to upload pdf file while `ghostscript_enabled` is false. 
